### PR TITLE
vscodeのMakefile周りの拡張を一部抑制する

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "php.version": "8.3"
+    "php.version": "8.3",
+    "makefile.configureOnOpen": false
 }


### PR DESCRIPTION
vscodeで使用中に、MakefileとC++周りの拡張で確認ボックスが出てくることがあります。
これはこの開発では不要なので使わないように設定を入れてみました。